### PR TITLE
(fix) lower ttr to 2 minutes

### DIFF
--- a/src/jobs/UploadVideoJob.php
+++ b/src/jobs/UploadVideoJob.php
@@ -16,7 +16,7 @@ class UploadVideoJob extends BaseJob implements \yii\queue\RetryableJobInterface
 
     public function getTtr()
     {
-        return 15 * 60;
+        return 2 * 60; // 2 minutes
     }
 
     public function canRetry($attempt, $error)


### PR DESCRIPTION
ttr is waited between tries, which make them way too long.