### PR TITLE
(fix) Check for rootPath property

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -14,7 +14,7 @@ class Folder
         $path = '';
         
         if (property_exists($fs, 'rootPath')) {
-            $path = $asset->getVolume()->getFs()->rootPath;
+            $path = $fs->rootPath;
         }
         
         $folderPath = $asset->getFolder()->path;

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -10,7 +10,13 @@ class Folder
      */
     public static function getAssetFolderPath($asset): string
     {
-        $path = $asset->getVolume()->getFs()->rootPath;
+        $fs = $asset->getVolume()->getFs();
+        $path = '';
+        
+        if (property_exists($fs, 'rootPath')) {
+            $path = $asset->getVolume()->getFs()->rootPath;
+        }
+        
         $folderPath = $asset->getFolder()->path;
         if ($folderPath) {
             $path .= '/' . $folderPath;


### PR DESCRIPTION
Seems like not all file systems have the rootPath property.

We ran into an issue similar to #7 but with the servd assets plugin. Which is S3 under the hood.

Checking for rootPath and defaulting to an empty string seems to make everything work again. 

**I wasn't able to test a local filesystem to see if this caused any issues there.**