### PR TITLE
Fix: Fs::path does not exist for AWS S3 filesystem

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -18,7 +18,7 @@ class Folder
         $path = '';
 
         // Start with the volume's path
-        if ($fs->path) {
+        if (property_exists($fs, 'path')) {
             $path = App::parseEnv($fs->path);
         }
         // or start with rootPath, if it exists?


### PR DESCRIPTION
Check for `path` with `property_exists` so it doesn't throw a property unknown error.

For more context: I'm using Craft's official AWS S3 plugin. The bucket is private with public access through AWS Cloudfront.

After this change uploading via the URL works, form data uploads fail(_which might be a local issue_).