### PR TITLE
(fix) Broken case in uid header

### DIFF
--- a/src/client/CloudflareVideoStreamClient.php
+++ b/src/client/CloudflareVideoStreamClient.php
@@ -126,17 +126,30 @@ class CloudflareVideoStreamClient
             return [
                 'error' => 'Error creating TUS request',
                 'message' => $uploadRes->getBody()->getContents(),
+                'status' => $uploadRes->getStatusCode(),
             ];
         }
 
         $headers = $uploadRes->getHeaders();
         $location = $headers['Location'][0];
-        $uid = $headers['stream-media-id'][0];
+        // Somehow, Cloudflare is inconsistent with the case of the headers
+        $uid = isset($headers['Stream-Media-Id'][0]) ?
+            $headers['Stream-Media-Id'][0] :
+            ($headers['stream-media-id'][0] ?? null);
 
         if (!$location) {
             return [
                 'error' => 'Error getting TUS location',
                 'message' => $uploadRes->getBody()->getContents(),
+                'headers' => $headers,
+            ];
+        }
+
+        if (!$uid) {
+            return [
+                'error' => 'Error getting TUS uid',
+                'message' => $uploadRes->getBody()->getContents(),
+                'headers' => $headers,
             ];
         }
 


### PR DESCRIPTION
Somehow, the old code with the lower case http header key no longer works under different environnements.

This make sure we can work with both.